### PR TITLE
Fix:  Reservation date overlaps

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -90,6 +90,16 @@
 			<artifactId>s3</artifactId>
 			<version>2.25.14</version>
 		</dependency>
+        <dependency>
+            <groupId>com.stripe</groupId>
+            <artifactId>stripe-java</artifactId>
+            <version>24.18.0</version>
+        </dependency>
+        <dependency>
+            <groupId>com.google.code.gson</groupId>
+            <artifactId>gson</artifactId>
+            <version>2.11.0</version>
+        </dependency>
 	</dependencies>
 
 	<build>

--- a/src/main/java/com/project/CarGo/controller/AppController.java
+++ b/src/main/java/com/project/CarGo/controller/AppController.java
@@ -1,0 +1,30 @@
+package com.project.CarGo.controller;
+
+import com.project.CarGo.entity.User;
+import com.project.CarGo.repository.UserRepository;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+
+@Controller
+public class AppController {
+
+    UserRepository userRepository;
+
+    public AppController(UserRepository userRepository) {
+        this.userRepository = userRepository;
+    }
+
+    @GetMapping("/admin/dashboard")
+    public String adminDashboard(Model model, Authentication authentication) {
+        String email = authentication.getName();
+
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new UsernameNotFoundException("User not found: " + email));
+
+        model.addAttribute("user", user);
+        return "admin-dashboard";
+    }
+}

--- a/src/main/java/com/project/CarGo/controller/PaymentController.java
+++ b/src/main/java/com/project/CarGo/controller/PaymentController.java
@@ -1,0 +1,4 @@
+package com.project.CarGo.controller;
+
+public class PaymentController {
+}

--- a/src/main/java/com/project/CarGo/controller/PaymentController.java
+++ b/src/main/java/com/project/CarGo/controller/PaymentController.java
@@ -1,4 +1,57 @@
 package com.project.CarGo.controller;
 
+import com.project.CarGo.entity.Reservation;
+import com.project.CarGo.repository.ReservationRepository;
+import com.project.CarGo.service.StripeService;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.ui.Model;
+
+import java.util.Map;
+
+@Controller
+@RequestMapping
 public class PaymentController {
+
+    private final ReservationRepository reservationRepository;
+    private final StripeService stripeService;
+
+    public PaymentController(ReservationRepository reservationRepository, StripeService stripeService) {
+        this.reservationRepository = reservationRepository;
+        this.stripeService = stripeService;
+    }
+
+    @Value("${stripe.publishable-key}")
+    private String publishableKey;
+
+    @GetMapping("/checkout/{reservationId}")
+    public String checkoutPage(@PathVariable Long reservationId, Model model) {
+        Reservation r = reservationRepository.findById(reservationId).orElseThrow();
+        model.addAttribute("reservation", r);
+        model.addAttribute("publishableKey", publishableKey);
+        return "checkout";
+    }
+
+    @PostMapping("/api/payments/create-intent")
+    @ResponseBody
+    public ResponseEntity<Map<String,String>> createIntent(@RequestParam Long reservationId) throws com.stripe.exception.StripeException {
+        var r = reservationRepository.findById(reservationId).orElseThrow();
+        com.stripe.model.PaymentIntent pi;
+        if (r.getStripePaymentId() != null && !r.getStripePaymentId().isBlank()) {
+            pi = stripeService.retrieve(r.getStripePaymentId());
+            if ("succeeded".equals(pi.getStatus())) return ResponseEntity.ok(Map.of("alreadyPaid","true"));
+            if ("canceled".equals(pi.getStatus())) {
+                pi = stripeService.createPaymentIntentForReservation(r);
+                r.setStripePaymentId(pi.getId());
+                reservationRepository.save(r);
+            }
+        } else {
+            pi = stripeService.createPaymentIntentForReservation(r);
+            r.setStripePaymentId(pi.getId());
+            reservationRepository.save(r);
+        }
+        return ResponseEntity.ok(Map.of("clientSecret", pi.getClientSecret(), "publishableKey", publishableKey));
+    }
 }

--- a/src/main/java/com/project/CarGo/controller/ReservationController.java
+++ b/src/main/java/com/project/CarGo/controller/ReservationController.java
@@ -118,8 +118,12 @@ public class ReservationController {
         reservation.setTotalPrice(total);
         if (reservation.getStatus() == null) reservation.setStatus(ReservationStatus.PENDING);
 
+        if (reservationService.checkReservationOverlap(reservation)) {
+            ra.addFlashAttribute("error", "Reservation add failed. Reservation overlap.");
+            return "redirect:/admin/reservations";
+        }
         reservationRepository.save(reservation);
-        ra.addFlashAttribute("success", "Reservation created successfully.");
+        ra.addFlashAttribute("success", "Reservation added successfully.");
         return "redirect:/admin/reservations";
     }
 
@@ -162,7 +166,10 @@ public class ReservationController {
 
         double total = reservationService.calculateTotalPrice(vehicle, reservation);
         reservation.setTotalPrice(total);
-        
+        if (reservationService.checkReservationOverlap(reservation)) {
+            ra.addFlashAttribute("error", "Reservation update failed. Reservation overlap.");
+            return "redirect:/admin/reservations";
+        }
         reservationRepository.save(reservation);
         ra.addFlashAttribute("success", "Reservation updated successfully.");
         return "redirect:/admin/reservations";
@@ -172,7 +179,7 @@ public class ReservationController {
     public String showReservationsByUser(Model model) {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
         String email = authentication.getName();
-        List<Reservation> reservations  = reservationRepository.findAllByUser_Email(email);
+        List<Reservation> reservations = reservationRepository.findAllByUser_Email(email);
         model.addAttribute("reservations", reservations);
         return "user-reservations";
     }

--- a/src/main/java/com/project/CarGo/controller/StripeWebhookController.java
+++ b/src/main/java/com/project/CarGo/controller/StripeWebhookController.java
@@ -1,0 +1,4 @@
+package com.project.CarGo.controller;
+
+public class StripeWebhookController {
+}

--- a/src/main/java/com/project/CarGo/controller/StripeWebhookController.java
+++ b/src/main/java/com/project/CarGo/controller/StripeWebhookController.java
@@ -1,4 +1,106 @@
 package com.project.CarGo.controller;
 
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import com.project.CarGo.entity.ReservationStatus;
+import com.project.CarGo.repository.ReservationRepository;
+import com.project.CarGo.service.StripeService;
+import com.stripe.exception.SignatureVerificationException;
+import com.stripe.exception.StripeException;
+import com.stripe.model.Charge;
+import com.stripe.model.Event;
+import com.stripe.model.PaymentIntent;
+import com.stripe.net.Webhook;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.ResponseEntity;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/stripe")
 public class StripeWebhookController {
+
+    private final ReservationRepository reservationRepository;
+    private final StripeService stripeService;
+
+    public StripeWebhookController(ReservationRepository reservationRepository, StripeService stripeService) {
+        this.reservationRepository = reservationRepository;
+        this.stripeService = stripeService;
+    }
+
+    @Value("${stripe.webhook-secret:}")
+    private String webhookSecret;
+
+    @PostMapping("/webhook")
+    @Transactional
+    public ResponseEntity<String> handle(@RequestHeader(value = "Stripe-Signature", required = false) String sigHeader,
+                                         @RequestBody String payload) {
+        Event event;
+        try {
+            if (webhookSecret != null && !webhookSecret.isBlank() && sigHeader != null) {
+                event = Webhook.constructEvent(payload, sigHeader, webhookSecret);
+            } else {
+                event = Event.GSON.fromJson(payload, Event.class);
+            }
+        } catch (SignatureVerificationException e) {
+            return ResponseEntity.badRequest().body("Invalid signature");
+        }
+
+        String type = event.getType();
+
+        if (type.startsWith("payment_intent.")) {
+            PaymentIntent pi = (PaymentIntent) event.getDataObjectDeserializer().getObject().orElse(null);
+            if (pi == null) {
+                JsonObject o = JsonParser.parseString(payload).getAsJsonObject().getAsJsonObject("data").getAsJsonObject("object");
+                String id = o.has("id") ? o.get("id").getAsString() : null;
+                if (id != null) {
+                    try { pi = stripeService.retrieve(id); } catch (StripeException ignored) {}
+                }
+            }
+            if (pi != null) upsert(pi, toPs(type));
+        } else if (type.startsWith("charge.")) {
+            Charge ch = (Charge) event.getDataObjectDeserializer().getObject().orElse(null);
+            String piId = ch != null ? ch.getPaymentIntent() : null;
+            if (piId == null) {
+                JsonObject o = JsonParser.parseString(payload).getAsJsonObject().getAsJsonObject("data").getAsJsonObject("object");
+                if (o.has("payment_intent")) piId = o.get("payment_intent").getAsString();
+            }
+            if (piId != null) {
+                try {
+                    PaymentIntent pi = stripeService.retrieve(piId);
+                    upsert(pi, toPs(type));
+                } catch (StripeException ignored) {}
+            }
+        }
+
+        return ResponseEntity.ok("ok");
+    }
+
+    private void upsert(PaymentIntent pi, String ps) {
+        if (ps == null) return;
+        String piId = pi.getId();
+        var r = reservationRepository.findByStripePaymentId(piId)
+                .orElseGet(() -> {
+                    String rid = pi.getMetadata() != null ? pi.getMetadata().get("reservationId") : null;
+                    if (rid == null) return null;
+                    try { return reservationRepository.findById(Long.parseLong(rid)).orElse(null); }
+                    catch (NumberFormatException e) { return null; }
+                });
+        if (r == null) return;
+        r.setStripePaymentId(piId);
+        r.setPaymentStatus(ps);
+        if ("succeeded".equals(ps)) {
+            r.setStatus(ReservationStatus.PAID);
+            r.setHoldExpiresAt(null);
+        } else if ("canceled".equals(ps)) {
+            r.setStatus(ReservationStatus.CANCELLED);
+        }
+        reservationRepository.save(r);
+    }
+
+    private String toPs(String type) {
+        if ("payment_intent.succeeded".equals(type) || "charge.succeeded".equals(type)) return "succeeded";
+        if ("payment_intent.canceled".equals(type) || "payment_intent.payment_failed".equals(type) || "charge.failed".equals(type)) return "canceled";
+        return null;
+    }
 }

--- a/src/main/java/com/project/CarGo/entity/Reservation.java
+++ b/src/main/java/com/project/CarGo/entity/Reservation.java
@@ -34,10 +34,12 @@ public class Reservation {
 
     private double totalPrice;
 
+    @Temporal(TemporalType.DATE)
     @DateTimeFormat(pattern = "yyyy-MM-dd")
     @NotNull(message="Start date cannot be null.")
     private Date reservationStartDate;
 
+    @Temporal(TemporalType.DATE)
     @DateTimeFormat(pattern = "yyyy-MM-dd")
     @NotNull(message="End date cannot be null.")
     private Date reservationEndDate;

--- a/src/main/java/com/project/CarGo/entity/Reservation.java
+++ b/src/main/java/com/project/CarGo/entity/Reservation.java
@@ -1,7 +1,6 @@
 package com.project.CarGo.entity;
 
 import jakarta.persistence.*;
-import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import lombok.*;
 import org.springframework.format.annotation.DateTimeFormat;
@@ -9,7 +8,7 @@ import org.springframework.format.annotation.DateTimeFormat;
 import java.util.Date;
 
 @Entity
-@Table(name = "reservations" /*, uniqueConstraints = {} <-- remove the email constraint */)
+@Table(name = "reservations")
 @Getter
 @Setter
 @NoArgsConstructor
@@ -24,7 +23,6 @@ public class Reservation {
     @ManyToOne(fetch = FetchType.LAZY, optional = false)
     @JoinColumn(name = "userId")
     private User user;
-
 
     @jakarta.validation.constraints.NotNull(message="Vehicle Cannot be null.")
     @jakarta.validation.constraints.Positive
@@ -44,7 +42,11 @@ public class Reservation {
     @NotNull(message="End date cannot be null.")
     private Date reservationEndDate;
 
+    @Column(name = "stripe_payment_id", length = 64)
     private String stripePaymentId;
+
+    @Column(name = "payment_status", length = 32)
+    private String paymentStatus;
 
     @DateTimeFormat
     private Date creationDate;
@@ -62,4 +64,9 @@ public class Reservation {
     void onUpdate() {
         updateDate = new Date();
     }
+
+    @Temporal(TemporalType.TIMESTAMP)
+    @Column(name = "hold_expires_at")
+    private Date holdExpiresAt;
+
 }

--- a/src/main/java/com/project/CarGo/entity/ReservationStatus.java
+++ b/src/main/java/com/project/CarGo/entity/ReservationStatus.java
@@ -9,7 +9,8 @@ public enum ReservationStatus {
     PENDING("PENDING"),
     PAID("PAID"),
     IN_PROGRESS("IN PROGRESS"),
-    COMPLETED("COMPLETED");
+    COMPLETED("COMPLETED"),
+    CANCELLED("CANCELLED");
 
     private final String displayName;
 }

--- a/src/main/java/com/project/CarGo/repository/ReservationRepository.java
+++ b/src/main/java/com/project/CarGo/repository/ReservationRepository.java
@@ -11,5 +11,6 @@ public interface ReservationRepository extends JpaRepository<Reservation, Long> 
     @Query("select r from Reservation r left join fetch r.user")
     List<Reservation> findAllWithUser();
     List<Reservation> findAllByUser_Email(String email);
+    List<Reservation> findAllByVehicleId(Long id);
 
 }

--- a/src/main/java/com/project/CarGo/repository/ReservationRepository.java
+++ b/src/main/java/com/project/CarGo/repository/ReservationRepository.java
@@ -4,13 +4,27 @@ package com.project.CarGo.repository;
 import com.project.CarGo.entity.Reservation;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import java.util.Date;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface ReservationRepository extends JpaRepository<Reservation, Long> {
     @Query("select r from Reservation r left join fetch r.user")
     List<Reservation> findAllWithUser();
+
+    @Query("""
+select count(r) from Reservation r
+where r.vehicleId = :vehicleId
+  and r.status <> com.project.CarGo.entity.ReservationStatus.CANCELLED
+  and r.reservationStartDate < :end
+  and r.reservationEndDate > :start
+  and (:excludeId is null or r.id <> :excludeId)
+""")
+    long countOverlaps(Long vehicleId, Date start, Date end, Long excludeId);
+
     List<Reservation> findAllByUser_Email(String email);
     List<Reservation> findAllByVehicleId(Long id);
+    Optional<Reservation> findByStripePaymentId(String stripePaymentId);
 
 }

--- a/src/main/java/com/project/CarGo/repository/ReservationRepository.java
+++ b/src/main/java/com/project/CarGo/repository/ReservationRepository.java
@@ -4,6 +4,8 @@ package com.project.CarGo.repository;
 import com.project.CarGo.entity.Reservation;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
 import java.util.Date;
 
 import java.util.List;
@@ -13,15 +15,19 @@ public interface ReservationRepository extends JpaRepository<Reservation, Long> 
     @Query("select r from Reservation r left join fetch r.user")
     List<Reservation> findAllWithUser();
 
-    @Query("""
-select count(r) from Reservation r
-where r.vehicleId = :vehicleId
-  and r.status <> com.project.CarGo.entity.ReservationStatus.CANCELLED
-  and r.reservationStartDate < :end
-  and r.reservationEndDate > :start
-  and (:excludeId is null or r.id <> :excludeId)
-""")
-    long countOverlaps(Long vehicleId, Date start, Date end, Long excludeId);
+    @Query(value = """
+  SELECT COUNT(*)
+  FROM reservations r
+  WHERE r.vehicle_id = :vehicleId
+    AND r.status <> 'CANCELLED'
+    AND NOT (r.reservation_end_date <= :start OR r.reservation_start_date >= :end)
+    AND (:excludeId IS NULL OR r.id <> :excludeId)
+""", nativeQuery = true)
+    long countOverlaps(@Param("vehicleId") Long vehicleId,
+                       @Param("start") Date start,
+                       @Param("end")   Date end,
+                       @Param("excludeId") Long excludeId);
+
 
     List<Reservation> findAllByUser_Email(String email);
     List<Reservation> findAllByVehicleId(Long id);

--- a/src/main/java/com/project/CarGo/security/SecurityConfig.java
+++ b/src/main/java/com/project/CarGo/security/SecurityConfig.java
@@ -16,7 +16,10 @@ public class SecurityConfig {
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http
+                .csrf(csrf -> csrf.ignoringRequestMatchers("/api/payments/**", "/stripe/webhook"))
                 .authorizeHttpRequests(auth -> auth
+                        .requestMatchers("/stripe/webhook").permitAll()
+                        .requestMatchers("/reservations/quick-book").hasAnyRole("USER","ADMIN")
                         .requestMatchers("/", "/index", "/register", "/login",
                                 "/css/**", "/js/**", "/images/**", "/vehicles/**").permitAll()
                         .requestMatchers("/admin/**").hasRole("ADMIN")

--- a/src/main/java/com/project/CarGo/service/ReservationService.java
+++ b/src/main/java/com/project/CarGo/service/ReservationService.java
@@ -2,15 +2,22 @@ package com.project.CarGo.service;
 
 import com.project.CarGo.entity.Reservation;
 import com.project.CarGo.entity.Vehicle;
+import com.project.CarGo.repository.ReservationRepository;
 import com.project.CarGo.repository.VehicleRepository;
 import org.springframework.stereotype.Service;
+
+import java.math.BigDecimal;
+import java.util.Date;
+import java.util.List;
 
 @Service
 public class ReservationService {
     private final VehicleRepository vehicleRepository;
+    private final ReservationRepository reservationRepository;
 
-    public ReservationService(VehicleRepository vehicleRepository) {
+    public ReservationService(VehicleRepository vehicleRepository, ReservationRepository reservationRepository) {
         this.vehicleRepository = vehicleRepository;
+        this.reservationRepository= reservationRepository;
     }
 
     public double calculateTotalPrice(Vehicle vehicle, Reservation reservation) {
@@ -20,6 +27,23 @@ public class ReservationService {
         long days = ((end.getTime() - start.getTime()) / (1000 * 60 * 60 * 24)) + 1;
         if (days <= 0) days = 1;
 
-        return vehicle.getDailyRate().multiply(java.math.BigDecimal.valueOf(days)).doubleValue();
+        return vehicle.getDailyRate().multiply(BigDecimal.valueOf(days)).doubleValue();
+    }
+
+    public boolean checkReservationOverlap(Reservation reservation) {
+        Date start = reservation.getReservationStartDate();
+        Date end   = reservation.getReservationEndDate();
+        Vehicle vehicle = vehicleRepository.getOne(reservation.getVehicleId());
+
+        List<Reservation> allReservationsById = reservationRepository.findAllByVehicleId(vehicle.getId());
+
+        for (Reservation r : allReservationsById) {
+            if((r.getReservationEndDate().after(start) && r.getReservationStartDate().after(end)) ||
+                r.getReservationEndDate().before(start) && r.getReservationStartDate().before(end))
+            {
+                return false;
+            }
+        }
+        return true;
     }
 }

--- a/src/main/java/com/project/CarGo/service/StripeService.java
+++ b/src/main/java/com/project/CarGo/service/StripeService.java
@@ -1,0 +1,4 @@
+package com.project.CarGo.service;
+
+public class StripeService {
+}

--- a/src/main/java/com/project/CarGo/service/StripeService.java
+++ b/src/main/java/com/project/CarGo/service/StripeService.java
@@ -1,4 +1,39 @@
 package com.project.CarGo.service;
 
+import com.project.CarGo.entity.Reservation;
+import com.stripe.Stripe;
+import com.stripe.exception.StripeException;
+import com.stripe.model.PaymentIntent;
+import com.stripe.param.PaymentIntentCreateParams;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.Objects;
+
+@Service
 public class StripeService {
+
+    @Value("${stripe.secret-key}")
+    private String secretKey;
+
+    public PaymentIntent createPaymentIntentForReservation(Reservation r) throws StripeException {
+        Stripe.apiKey = secretKey;
+        BigDecimal amount = BigDecimal.valueOf(r.getTotalPrice()).movePointRight(2).setScale(0, RoundingMode.HALF_UP);
+        PaymentIntentCreateParams params = PaymentIntentCreateParams.builder()
+                .setAmount(amount.longValueExact())
+                .setCurrency("cad")
+                .setAutomaticPaymentMethods(PaymentIntentCreateParams.AutomaticPaymentMethods.builder().setEnabled(true).build())
+                .putMetadata("reservationId", String.valueOf(r.getId()))
+                .putMetadata("vehicleId", r.getVehicleId() == null ? "" : String.valueOf(r.getVehicleId()))
+                .putMetadata("userEmail", r.getUser() == null ? "" : Objects.toString(r.getUser().getEmail(), ""))
+                .build();
+        return PaymentIntent.create(params);
+    }
+
+    public PaymentIntent retrieve(String paymentIntentId) throws StripeException {
+        Stripe.apiKey = secretKey;
+        return PaymentIntent.retrieve(paymentIntentId);
+    }
 }

--- a/src/main/resources/templates/admin-dashboard.html
+++ b/src/main/resources/templates/admin-dashboard.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<html lang="en"
+      xmlns:th="http://www.thymeleaf.org"
+      xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
+      layout:decorate="~{base}">
+<head>
+    <title>Categories</title>
+    <style>
+        .welcome {
+            display: flex;
+            font-size: 3rem;
+            justify-content: center;
+            padding-top: 3%;
+        }
+
+        .grid-container {
+            padding-top: 70px;
+            display: flex;
+            flex-wrap: wrap;
+            justify-content: center;
+            gap: 20px;
+            max-width: 50%;
+            margin: 0 auto;
+        }
+
+        .grid-item {
+            max-height: 150px;
+            flex: 0 0 calc(50% - 20px); /* 3 per row with some spacing */
+            aspect-ratio: 1; /* Make square */
+            background-color: #2d2d44;
+            border: 1px solid #999;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            font-weight: bold;
+            box-shadow: 0 2px 6px rgba(0, 0, 0, 0.4);
+            border-radius: 10px;
+        }
+
+        .grid-item:hover {
+            background-color: #307ccf;
+        }
+
+        .grid-item a {
+            text-decoration: none;
+            color: white;
+        }
+
+    </style>
+</head>
+<section layout:fragment="content">
+    <div class="welcome">
+        <span th:text="'Welcome, ' + ${user.firstName}">Welcome, Admin</span>
+    </div>
+    <div class="grid-container">
+        <div class="grid-item"><a href="/vehicles">Home</a></div>
+        <div class="grid-item"><a href="/admin/vehicles">Vehicles</a></div>
+        <div class="grid-item"><a href="/admin/categories">Vehicle Categories</a></div>
+        <div class="grid-item"><a href="/admin/reservations">Reservations</a></div>
+    </div>
+</section>

--- a/src/main/resources/templates/checkout.html
+++ b/src/main/resources/templates/checkout.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>$Title$</title>
+</head>
+<body>
+$END$
+</body>
+</html>

--- a/src/main/resources/templates/checkout.html
+++ b/src/main/resources/templates/checkout.html
@@ -1,10 +1,57 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en"
+      xmlns:th="http://www.thymeleaf.org"
+      xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
+      layout:decorate="~{base}">
 <head>
-  <meta charset="UTF-8">
-  <title>$Title$</title>
+    <title>Checkout</title>
+    <script src="https://js.stripe.com/v3/"></script>
 </head>
-<body>
-$END$
-</body>
+
+<section layout:fragment="content">
+    <div class="container my-5" style="max-width:600px;">
+        <h3 class="mb-3">Complete Payment</h3>
+        <div class="mb-2">
+            <strong>Reservation</strong>
+            <span th:text="${reservation.id}"></span>
+        </div>
+        <div class="mb-4">
+            <strong>Total</strong>
+            <span th:text="${reservation.totalPrice}"></span> CAD
+        </div>
+        <div id="payment-element"></div>
+        <button id="submit" class="btn btn-primary mt-3 w-100">Pay now</button>
+        <div id="message" class="mt-3 text-danger"></div>
+    </div>
+
+    <script th:inline="javascript">
+        const reservationId = /*[[${reservation.id}]]*/ 0;
+        const publishableKey = /*[[${publishableKey}]]*/ "";
+        let stripe;
+        async function init() {
+            const resp = await fetch("/api/payments/create-intent", {
+                method: "POST",
+                headers: {"Content-Type": "application/x-www-form-urlencoded"},
+                body: new URLSearchParams({reservationId})
+            });
+            const data = await resp.json();
+            stripe = Stripe(data.publishableKey);
+            const elements = stripe.elements({clientSecret: data.clientSecret});
+            const paymentElement = elements.create("payment");
+            paymentElement.mount("#payment-element");
+            document.getElementById("submit").addEventListener("click", async () => {
+                document.getElementById("submit").disabled = true;
+                const {error} = await stripe.confirmPayment({
+                    elements,
+                    confirmParams: { return_url: window.location.origin + "/user/reservations" }
+                });
+                if (error) {
+                    document.getElementById("message").textContent = error.message || "Payment failed";
+                    document.getElementById("submit").disabled = false;
+                }
+            });
+        }
+        init();
+    </script>
+</section>
 </html>

--- a/src/main/resources/templates/fragments/navbar.html
+++ b/src/main/resources/templates/fragments/navbar.html
@@ -28,7 +28,7 @@
           </span>
             </div>
             <div class="nav-item mx-3" sec:authorize="hasRole('ROLE_ADMIN')">
-                <a class="btn btn-primary" th:href="@{/admin/reservations}">View Reservations</a>
+                <a class="btn btn-primary" th:href="@{/admin/dashboard}">Admin Dashboard</a>
             </div>
             <div class="nav-item mx-3" sec:authorize="hasRole('ROLE_USER')">
                 <a class="btn btn-primary" th:href="@{/user/reservations}">My Reservations</a>

--- a/src/main/resources/templates/index-vehicles.html
+++ b/src/main/resources/templates/index-vehicles.html
@@ -107,7 +107,13 @@
 
                                     <div class="mt-3">
                                         <a th:href="@{'/vehicle/details/' + ${vehicle.id}}" class="btn btn-primary btn-sm">View Details</a>
-                                        <a th:href="@{'/reservation/book/' + ${vehicle.id}}" class="btn btn-success btn-sm">Book Now</a>
+                                        <form th:action="@{/reservations/quick-book}" method="post" class="d-inline">
+                                            <input type="hidden" name="vehicleId" th:value="${vehicle.id}">
+                                            <input type="hidden" name="startDate" th:value="${#dates.format(startDate, 'yyyy-MM-dd')}">
+                                            <input type="hidden" name="endDate" th:value="${#dates.format(endDate, 'yyyy-MM-dd')}">
+                                            <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}">
+                                            <button type="submit" class="btn btn-success btn-sm">Book Now</button>
+                                        </form>
                                     </div>
 
                                 </div>

--- a/src/main/resources/templates/reservations.html
+++ b/src/main/resources/templates/reservations.html
@@ -46,6 +46,9 @@
                 <td th:text="${reservation.totalPrice}">Total</td>
                 <td th:text="${#dates.format(reservation.reservationStartDate, 'yyyy-MM-dd')}"></td>
                 <td th:text="${#dates.format(reservation.reservationStartDate, 'yyyy-MM-dd')}"></td>
+                <td th:text="${reservation.status}"></td>
+                <td th:text="${reservation.paymentStatus}"></td>
+                <td th:text="${reservation.stripePaymentId}"></td>
                 <td>
                     <a th:href="@{'/admin/reservations/edit/' + ${reservation.id}}" class="btn btn-sm btn-primary">Update</a>
 

--- a/src/main/resources/templates/reservations.html
+++ b/src/main/resources/templates/reservations.html
@@ -45,10 +45,7 @@
                 <td th:text="${reservation.status.displayName}">Status</td>
                 <td th:text="${reservation.totalPrice}">Total</td>
                 <td th:text="${#dates.format(reservation.reservationStartDate, 'yyyy-MM-dd')}"></td>
-                <td th:text="${#dates.format(reservation.reservationStartDate, 'yyyy-MM-dd')}"></td>
-                <td th:text="${reservation.status}"></td>
-                <td th:text="${reservation.paymentStatus}"></td>
-                <td th:text="${reservation.stripePaymentId}"></td>
+                <td th:text="${#dates.format(reservation.reservationEndDate, 'yyyy-MM-dd')}"></td>
                 <td>
                     <a th:href="@{'/admin/reservations/edit/' + ${reservation.id}}" class="btn btn-sm btn-primary">Update</a>
 

--- a/src/main/resources/templates/user-reservations.html
+++ b/src/main/resources/templates/user-reservations.html
@@ -40,8 +40,6 @@
                 <td th:text="${reservation.vehicleId}">Vehicle</td>
                 <td th:text="${reservation.status.displayName}">Status</td>
                 <td th:text="${reservation.totalPrice}">Total</td>
-                <td th:text="${#dates.format(reservation.reservationStartDate, 'yyyy-MM-dd')}"></td>
-                <td th:text="${#dates.format(reservation.reservationStartDate, 'yyyy-MM-dd')}"></td>
                 <td>
                     <form th:action="@{'/user/reservations/delete/' + ${reservation.id}}"
                           method="post"


### PR DESCRIPTION
-   Changed duplicate start date to end date in table

-   Modified Reservation entity with temporal annotation to ensure only date gets stored (not time)

-   Modified SQL query in repository

-   Added check to quick book for user reservation on "Book Now" (although it should not be an option to choose a vehicle that has overlap)

-   Modified Add and edit ADMIN reservation endpoints to validate on form, instead of returning to reservations table