### PR TITLE
Admin can manage images in categories

### DIFF
--- a/src/main/java/com/project/CarGo/controller/CategoryController.java
+++ b/src/main/java/com/project/CarGo/controller/CategoryController.java
@@ -155,8 +155,12 @@ public class CategoryController {
                 .orElseThrow(() -> new IllegalArgumentException("Invalid category ID: " + id));
 
         if(!category.getImageUrl().isEmpty() && !category.getImageUrl().equals(DEFAULT_IMAGE_URL)) {
-            String fileName = getFileName(category.getImageUrl());
-            s3Service.deleteFile(fileName);
+            boolean usedByOtherCategories = categoryRepository.existsByImageUrlAndIdNot(category.getImageUrl(), id);
+
+            if (!usedByOtherCategories) {
+                String fileName = getFileName(category.getImageUrl());
+                s3Service.deleteFile(fileName);
+            }
         }
 
         categoryRepository.deleteById(id);

--- a/src/main/java/com/project/CarGo/repository/CategoryRepository.java
+++ b/src/main/java/com/project/CarGo/repository/CategoryRepository.java
@@ -7,4 +7,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface CategoryRepository extends JpaRepository<Category, Long> {
     boolean existsByTypeAndSubtype(CategoryType type, CategorySubtype subtype);
+    boolean existsByImageUrlAndIdNot(String imageUrl, Long id);
 }

--- a/src/main/resources/static/js/script.js
+++ b/src/main/resources/static/js/script.js
@@ -7,19 +7,30 @@ $(document).ready(function () {
     });
 });
 
-function previewFile(input) {
-    const preview = document.getElementById('imagePreview');
-    if (input.files && input.files[0]) {
-        const reader = new FileReader();
-        reader.onload = function (e) {
-            preview.src = e.target.result;
-        }
-        reader.readAsDataURL(input.files[0]);
-    }
-}
+const DEFAULT_IMAGE_URL = document.getElementById('imageUrl').options[0].value;
 
-function selectExistingImage(select) {
-    const preview = document.getElementById('imagePreview');
-    preview.src = select.value;
-}
+const fileInput = document.getElementById('imageFile');
+const selectInput = document.getElementById('imageUrl');
+const preview = document.getElementById('imagePreview');
+
+fileInput.addEventListener('change', () => {
+    const file = fileInput.files[0];
+    if(file) {
+        const reader = new FileReader();
+        reader.onload = e => preview.src = e.target.result;
+        reader.readAsDataURL(file);
+
+        selectInput.value = DEFAULT_IMAGE_URL;
+    }
+});
+
+selectInput.addEventListener('change', () => {
+    if(selectInput.value === DEFAULT_IMAGE_URL || !selectInput.value) {
+        preview.src = DEFAULT_IMAGE_URL;
+    } else {
+        preview.src = selectInput.value;
+    }
+
+    fileInput.value = '';
+});
 

--- a/src/main/resources/static/js/script.js
+++ b/src/main/resources/static/js/script.js
@@ -6,3 +6,20 @@ $(document).ready(function () {
         }]
     });
 });
+
+function previewFile(input) {
+    const preview = document.getElementById('imagePreview');
+    if (input.files && input.files[0]) {
+        const reader = new FileReader();
+        reader.onload = function (e) {
+            preview.src = e.target.result;
+        }
+        reader.readAsDataURL(input.files[0]);
+    }
+}
+
+function selectExistingImage(select) {
+    const preview = document.getElementById('imagePreview');
+    preview.src = select.value;
+}
+

--- a/src/main/resources/templates/category-form.html
+++ b/src/main/resources/templates/category-form.html
@@ -19,7 +19,7 @@
 
             <!-- Shared Add/Edit Form -->
             <form th:action="@{${category.id} != null ? '/admin/category/edit/' + ${category.id} : '/admin/category/add'}"
-                  th:object="${category}" method="POST">
+                  th:object="${category}" method="POST" enctype="multipart/form-data">
                 <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}"/>
 
                 <div class="mb-3">
@@ -45,9 +45,13 @@
                 </div>
 
                 <div class="mb-3">
-                    <label class="form-label" for="imageUrl">Image URL</label>
-                    <input id="imageUrl" type="text" th:field="*{imageUrl}" class="form-control">
+                    <label class="form-label" for="imageFile">Image URL</label>
+                    <input id="imageFile" type="file" th:field="*{imageUrl}" name="imageFile" class="form-control">
                     <div th:if="${#fields.hasErrors('imageUrl')}" class="alert alert-danger" th:errors="*{imageUrl}"></div>
+
+                    <div th:if="${imageUrl}" class="mt-2">
+                        <img th:src="${imageUrl}" alt="Category Image" style="max-width: 200px;"/>
+                    </div>
                 </div>
 
                 <button class="btn btn-primary w-100" type="submit"

--- a/src/main/resources/templates/category-form.html
+++ b/src/main/resources/templates/category-form.html
@@ -17,7 +17,6 @@
             <div th:if="${success}" class="alert alert-success" th:text="${success}"></div>
             <div th:if="${error}" class="alert alert-danger" th:text="${error}"></div>
 
-            <!-- Shared Add/Edit Form -->
             <form th:action="@{${category.id} != null ? '/admin/category/edit/' + ${category.id} : '/admin/category/add'}"
                   th:object="${category}" method="POST" enctype="multipart/form-data">
                 <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}"/>
@@ -45,13 +44,14 @@
                 </div>
 
                 <div class="mb-3">
-                    <label class="form-label" for="imageFile">Upload Image</label>
-                    <input id="imageFile" type="file" name="imageFile" class="form-control">
+                    <label class="form-label" for="imageFile">Upload New Image</label>
+                    <input id="imageFile" type="file" name="imageFile" class="form-control"
+                           onchange="previewFile(this)">
                 </div>
 
                 <div class="mb-3" th:if="${imageUrlsS3 != null and !imageUrlsS3.isEmpty()}">
                     <label class="form-label" for="imageUrl">Or Choose Existing Image</label>
-                    <select id="imageUrl" th:field="*{imageUrl}" class="form-select">
+                    <select id="imageUrl" th:field="*{imageUrl}" class="form-select" onchange="selectExistingImage(this)">
                         <option value="">-- Select Existing Image --</option>
                         <option th:each="url : ${imageUrlsS3}"
                                 th:value="${url}"
@@ -61,13 +61,12 @@
                     </select>
                 </div>
 
-                <div th:if="${imageUrl != null}" class="mt-3 mb-3">
-                    <small class="form-text text-muted">
-                        Current file:
-                        <span th:text="${#strings.substring(imageUrl, imageUrl.lastIndexOf('/') + 1)}"></span>
-                    </small>
-                    <br>
-                    <img th:src="${imageUrl}" alt="Category Image" style="max-width: 200px;">
+                <div class="mb-3" th:if="${category.imageUrl != null}">
+                    <small class="form-text text-muted">Preview:</small>
+                    <img id="imagePreview"
+                         th:src="${category.imageUrl}"
+                         alt="Category Image"
+                         style="max-width: 200px; display: block; margin-top: 5px;">
                 </div>
 
                 <button class="btn btn-primary w-100" type="submit"

--- a/src/main/resources/templates/category-form.html
+++ b/src/main/resources/templates/category-form.html
@@ -29,7 +29,6 @@
                                 th:value="${type}"
                                 th:text="${type.displayName}"></option>
                     </select>
-                    <div th:if="${#fields.hasErrors('type')}" class="alert alert-danger" th:errors="*{type}"></div>
                 </div>
 
                 <div class="mb-3">
@@ -40,19 +39,20 @@
                                 th:value="${subtype}"
                                 th:text="${subtype.displayName}"></option>
                     </select>
-                    <div th:if="${#fields.hasErrors('subtype')}" class="alert alert-danger" th:errors="*{subtype}"></div>
                 </div>
 
                 <div class="mb-3">
                     <label class="form-label" for="imageFile">Upload New Image</label>
-                    <input id="imageFile" type="file" name="imageFile" class="form-control"
-                           onchange="previewFile(this)">
+                    <input id="imageFile" type="file" name="imageFile" class="form-control">
                 </div>
 
-                <div class="mb-3" th:if="${imageUrlsS3 != null and !imageUrlsS3.isEmpty()}">
+                <div class="mb-3">
                     <label class="form-label" for="imageUrl">Or Choose Existing Image</label>
-                    <select id="imageUrl" th:field="*{imageUrl}" class="form-select" onchange="selectExistingImage(this)">
-                        <option value="">-- Select Existing Image --</option>
+                    <select id="imageUrl" th:field="*{imageUrl}" class="form-select">
+                        <option th:value="${DEFAULT_IMAGE_URL}"
+                                th:selected="${category.imageUrl == null || category.imageUrl == DEFAULT_IMAGE_URL}">
+                            Use Default Image
+                        </option>
                         <option th:each="url : ${imageUrlsS3}"
                                 th:value="${url}"
                                 th:text="${#strings.substring(url, url.lastIndexOf('/') + 1)}"
@@ -61,10 +61,10 @@
                     </select>
                 </div>
 
-                <div class="mb-3" th:if="${category.imageUrl != null}">
+                <div class="mb-3">
                     <small class="form-text text-muted">Preview:</small>
                     <img id="imagePreview"
-                         th:src="${category.imageUrl}"
+                         th:src="${category.imageUrl != null ? category.imageUrl : DEFAULT_IMAGE_URL}"
                          alt="Category Image"
                          style="max-width: 200px; display: block; margin-top: 5px;">
                 </div>

--- a/src/main/resources/templates/category-form.html
+++ b/src/main/resources/templates/category-form.html
@@ -45,13 +45,29 @@
                 </div>
 
                 <div class="mb-3">
-                    <label class="form-label" for="imageFile">Image URL</label>
-                    <input id="imageFile" type="file" th:field="*{imageUrl}" name="imageFile" class="form-control">
-                    <div th:if="${#fields.hasErrors('imageUrl')}" class="alert alert-danger" th:errors="*{imageUrl}"></div>
+                    <label class="form-label" for="imageFile">Upload Image</label>
+                    <input id="imageFile" type="file" name="imageFile" class="form-control">
+                </div>
 
-                    <div th:if="${imageUrl}" class="mt-2">
-                        <img th:src="${imageUrl}" alt="Category Image" style="max-width: 200px;"/>
-                    </div>
+                <div class="mb-3" th:if="${imageUrlsS3 != null and !imageUrlsS3.isEmpty()}">
+                    <label class="form-label" for="imageUrl">Or Choose Existing Image</label>
+                    <select id="imageUrl" th:field="*{imageUrl}" class="form-select">
+                        <option value="">-- Select Existing Image --</option>
+                        <option th:each="url : ${imageUrlsS3}"
+                                th:value="${url}"
+                                th:text="${#strings.substring(url, url.lastIndexOf('/') + 1)}"
+                                th:selected="${url == category.imageUrl}">
+                        </option>
+                    </select>
+                </div>
+
+                <div th:if="${imageUrl != null}" class="mt-3 mb-3">
+                    <small class="form-text text-muted">
+                        Current file:
+                        <span th:text="${#strings.substring(imageUrl, imageUrl.lastIndexOf('/') + 1)}"></span>
+                    </small>
+                    <br>
+                    <img th:src="${imageUrl}" alt="Category Image" style="max-width: 200px;">
                 </div>
 
                 <button class="btn btn-primary w-100" type="submit"


### PR DESCRIPTION
1. Updated category-form Thymeleaf template to upload image to S3 and use an existing image from S3.
2. Updated CategoryController
-GetMapping: /admin/categories, /admin/category/add, /admin/category/edit/{id}
-PostMapping: /admin/category/add, /admin/category/edit/{id}, /admin/category/delete/{id}
3. Added private method getFileName in CategoryController.
4. Added existsByImageUrlAndIdNot(String imageUrl, Long id) in CategoryRepository to prevent the deletion of images in S3 if it's used for multiple categories.
5. Updated script.js for preview of images.