### PR TITLE
Fix: Remove empty categories from vehicle categories dropdown on search

### DIFF
--- a/src/main/java/com/project/CarGo/controller/VehicleController.java
+++ b/src/main/java/com/project/CarGo/controller/VehicleController.java
@@ -127,7 +127,7 @@ public class VehicleController {
 
     @GetMapping("/vehicles")
     public String showFormToDisplayAvailableVehicles(Model model) {
-        model.addAttribute("categories", categoryRepository.findAll());
+        model.addAttribute("categories", categoryRepository.findCategoriesWithVehicles());
         return "index-vehicles";
     }
 
@@ -158,7 +158,7 @@ public class VehicleController {
 
         List<Vehicle> vehicles = vehicleRepository.findAvailableVehiclesByDateAndCategory(startDate, endDate, categoryId);
 
-        List<Category> categories = categoryRepository.findAll();
+        List<Category> categories = categoryRepository.findCategoriesWithVehicles();
 
         long rentalDays = ((endDate.getTime() - startDate.getTime()) / (1000 * 60 * 60 * 24)) + 1;
 

--- a/src/main/java/com/project/CarGo/repository/CategoryRepository.java
+++ b/src/main/java/com/project/CarGo/repository/CategoryRepository.java
@@ -4,8 +4,14 @@ import com.project.CarGo.entity.Category;
 import com.project.CarGo.entity.CategorySubtype;
 import com.project.CarGo.entity.CategoryType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.List;
 
 public interface CategoryRepository extends JpaRepository<Category, Long> {
     boolean existsByTypeAndSubtype(CategoryType type, CategorySubtype subtype);
     boolean existsByImageUrlAndIdNot(String imageUrl, Long id);
+
+    @Query("SELECT DISTINCT v.category FROM Vehicle v")
+    List<Category> findCategoriesWithVehicles();
 }


### PR DESCRIPTION
1. Updated /vehicles and /vehicles/available Controller endpoints.
2. Added query findCategoriesWithVehicles in CategoryRepository.